### PR TITLE
setup.py: move pytest-runner to test_requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ requirements = [
     'six',
 ]
 
-setup_requirements = ['pytest-runner', ]
+setup_requirements = []
 
-test_requirements = ['pytest>=3', ]
+test_requirements = ['pytest>=3', 'pytest-runner']
 
 setup(
     author="Nicolas Aimetti",


### PR DESCRIPTION
This fixes an issue with yocto build.
pytest-runner is only needed when running tests.