### PR TITLE
Drop the pytest-runner test dependency and “setup.py test” support

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,6 +7,5 @@ coverage==4.5.4
 twine==1.14.0
 
 pytest==4.6.5
-pytest-runner==5.1
 hypothesis==4.41.3
 strict_rfc3339==0.7

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,6 @@ requirements = [
 
 setup_requirements = []
 
-test_requirements = ['pytest>=3', 'hypothesis', 'strict_rfc3339']
-
 setup(
     author="Nicolas Aimetti",
     author_email='naimetti@yahoo.com.ar',
@@ -43,8 +41,6 @@ setup(
     name='rfc3339_validator',
     py_modules=['rfc3339_validator'],
     setup_requires=setup_requirements,
-    test_suite='tests',
-    tests_require=test_requirements,
     url='https://github.com/naimetti/rfc3339-validator',
     version='0.1.4',
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
 
 setup_requirements = []
 
-test_requirements = ['pytest>=3', 'pytest-runner', 'hypothesis', 'strict_rfc3339']
+test_requirements = ['pytest>=3', 'hypothesis', 'strict_rfc3339']
 
 setup(
     author="Nicolas Aimetti",


### PR DESCRIPTION
The `pytest-runner` package is [deprecated upstream](https://pypi.org/project/pytest-runner/). Its README now advises:

> pytest-runner depends on deprecated features of setuptools and relies on features that break security mechanisms in pip. For example ‘setup_requires’ and ‘tests_require’ bypass `pip --require-hashes`. See also [pypa/setuptools#1684](https://github.com/pypa/setuptools/issues/1684).
> 
> It is recommended that you:
> 
> - Remove `'pytest-runner'` from your `setup_requires`, preferably removing the `setup_requires` option.
> - Remove `'pytest'` and any other testing requirements from `tests_require`, preferably removing the `tests_requires` option.
> - Select a tool to bootstrap and then run tests such as tox.

This came up in a review of a proposed `python-rfc3339-validator` package for Fedora Linux.

----

This PR follows `pytest-runner` upstream’s advice (leaving the already-empty `setup_requires` for now). It removes support for `python setup.py test`, but testing via `tox` or direct use of `pytest` still work.

Fixes #6.